### PR TITLE
The "reload" library was not included as a transitive dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you use Maven, add these lines to your pom.xml in order to add the repository
 Then add the following dependencies for the core library:
 	
     <dependency>
-        <groupId>com.github.smeup</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
         <version>development-SNAPSHOT</version>
     </dependency>

--- a/assembly.xml
+++ b/assembly.xml
@@ -32,11 +32,11 @@
 
             <!-- Now, select which projects to include in this module-set. -->
             <includes>
-                <include>com.smeup.reload:base</include>
-                <include>com.smeup.reload:sql</include>
-                <include>com.smeup.reload:nosql</include>
-                <include>com.smeup.reload:manager</include>
-                <include>com.smeup.reload:jt400</include>
+                <include>com.github.smeup.reload:base</include>
+                <include>com.github.smeup.reload:sql</include>
+                <include>com.github.smeup.reload:nosql</include>
+                <include>com.github.smeup.reload:manager</include>
+                <include>com.github.smeup.reload:jt400</include>
             </includes>
             <binaries>
                 <outputDirectory>modules/maven-assembly-plugin</outputDirectory>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -30,14 +30,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.smeup.reload</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>development-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>base</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/base/src/test/kotlin/com/smeup/dbnative/PropertiesSerializationTest.kt
+++ b/base/src/test/kotlin/com/smeup/dbnative/PropertiesSerializationTest.kt
@@ -28,6 +28,7 @@ class DBFileFactoryTest {
         // Delete tmp file
         var tmpFile = File("src/test/resources/dds/properties/out/BRARTI0F.properties")
         if (tmpFile.exists()) tmpFile.delete()
+        tmpFile.parentFile.mkdirs()
 
         // Read metadata1 from properties
         var metadata1 = PropertiesSerializer.propertiesToMetadata("src/test/resources/dds/properties/", "BRARTI0F")

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -22,8 +22,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>reload</artifactId>
-        <groupId>com.smeup.reload</groupId>
-        <version>1.3.0-SNAPSHOT</version>
+        <groupId>com.github.smeup.reload</groupId>
+        <version>development-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -32,29 +32,29 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>sql</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>nosql</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>jt400</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>manager</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -73,7 +73,7 @@
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
-                            <finalName>reload-${version}</finalName>
+                            <finalName>reload-${project.version}</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/jt400/pom.xml
+++ b/jt400/pom.xml
@@ -29,14 +29,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.smeup.reload</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>development-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>jt400</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -44,14 +44,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -29,14 +29,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.smeup.reload</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>development-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>manager</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -44,21 +44,21 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>sql</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nosql/pom.xml
+++ b/nosql/pom.xml
@@ -30,14 +30,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.smeup.reload</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>development-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>nosql</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -45,14 +45,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>reload</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <modules>
         <module>base</module>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -29,14 +29,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.smeup.reload</groupId>
+        <groupId>com.github.smeup.reload</groupId>
         <artifactId>reload</artifactId>
-        <version>1.3.0-SNAPSHOT</version>
+        <version>development-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.smeup.reload</groupId>
+    <groupId>com.github.smeup.reload</groupId>
     <artifactId>sql</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>development-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -44,14 +44,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.smeup.reload</groupId>
+            <groupId>com.github.smeup.reload</groupId>
             <artifactId>base</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>development-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
To fix this problem I addressed the matter by using the same approach used for jariko, but if you have better ideas  I am willing to listen to your suggestions.

1. Changed groupId in pom to make it compliant with the groupid, as specified in README.md
2. Changed in the pom the name of snapshot version to development-SNAPSHOT, personally I have never understood the reason to label a development snapshot release with x.y.z-SNAPSHOT 

