### PR TITLE
Nexus deploy action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 name: Deploy to maven central
 on:
   push:
-    branches: [master, develop]
+    branches: [master, develop, nexus-deploy-action]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 name: Deploy to maven central
 on:
   push:
-    branches: [master, develop, nexus-deploy-action]
+    branches: [master, develop]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/smeup.yml
+++ b/.github/workflows/smeup.yml
@@ -2,7 +2,8 @@ name: Deploy to nexus
 on: 
   workflow_dispatch:
   push:
-    branches: [master, develop]
+#    branches: [master, develop]
+    branches: [nexus-deploy-action]
 env: 
   DISTRIBUTION: zulu
   JAVA_VERSION: 8
@@ -15,7 +16,8 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Set smeup nexus settings for snapshots
-      if: ${{ github.ref == 'refs/heads/develop' }}
+#      if: ${{ github.ref == 'refs/heads/develop' }}
+      if: ${{ github.ref == 'refs/heads/nexus-deploy-action' }}
       uses: actions/setup-java@v3
       with:
         distribution: ${{ env.DISTRIBUTION }}

--- a/.github/workflows/smeup.yml
+++ b/.github/workflows/smeup.yml
@@ -36,7 +36,7 @@ jobs:
         server-password: NEXUS_PASSWORD
 
     - name: Publish to smeup nexus
-      run: mvn deploy -DskipTests -Preload-nexus-deploy
+      run: mvn deploy -DskipTests
       env: 
         NEXUS_USER: ${{ secrets.NEXUS_USER }}
         NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/smeup.yml
+++ b/.github/workflows/smeup.yml
@@ -36,7 +36,7 @@ jobs:
 
     
     - name: Publish to smeup nexus
-      run: mvn deploy
+      run: mvn deploy -DskipTests -Preload-nexus-deploy
       env: 
         NEXUS_USER: ${{ secrets.NEXUS_USER }}
         NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/smeup.yml
+++ b/.github/workflows/smeup.yml
@@ -1,0 +1,44 @@
+name: Deploy to nexus
+on: 
+  workflow_dispatch:
+  push:
+    branches: [master, develop]
+env: 
+  DISTRIBUTION: zulu
+  JAVA_VERSION: 8
+
+jobs:
+  deploy-jardis-server:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set smeup nexus settings for snapshots
+      if: ${{ github.ref == 'refs/heads/develop' }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{ env.DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
+        server-id: snapshots
+        server-username: NEXUS_USER
+        server-password: NEXUS_PASSWORD
+  
+    - name: Set smeup nexus settings for releases
+      if: ${{ github.ref == 'refs/heads/master' }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{ env.DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
+        server-id: releases
+        server-username: NEXUS_USER
+        server-password: NEXUS_PASSWORD
+
+    
+    - name: Publish to smeup nexus
+      run: mvn deploy
+      env: 
+        NEXUS_USER: ${{ secrets.NEXUS_USER }}
+        NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+
+  

--- a/.github/workflows/smeup.yml
+++ b/.github/workflows/smeup.yml
@@ -1,9 +1,7 @@
 name: Deploy to nexus
-on: 
-  workflow_dispatch:
+on:
   push:
-#    branches: [master, develop]
-    branches: [nexus-deploy-action]
+    branches: [master, develop]
 env: 
   DISTRIBUTION: zulu
   JAVA_VERSION: 8
@@ -16,13 +14,13 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Set smeup nexus settings for snapshots
-#      if: ${{ github.ref == 'refs/heads/develop' }}
-      if: ${{ github.ref == 'refs/heads/nexus-deploy-action' }}
+      if: ${{ github.ref == 'refs/heads/develop' }}
       uses: actions/setup-java@v3
       with:
         distribution: ${{ env.DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}
         server-id: snapshots
+        cache: 'maven'
         server-username: NEXUS_USER
         server-password: NEXUS_PASSWORD
   
@@ -33,10 +31,10 @@ jobs:
         distribution: ${{ env.DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}
         server-id: releases
+        cache: 'maven'
         server-username: NEXUS_USER
         server-password: NEXUS_PASSWORD
 
-    
     - name: Publish to smeup nexus
       run: mvn deploy -DskipTests -Preload-nexus-deploy
       env: 

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ bin/
 *.iml
 /docker/mongodb/data/
 /base/src/test/resources/dds/properties/out/
-.gradle/
+.vscode

--- a/README.md
+++ b/README.md
@@ -54,20 +54,38 @@ We use [Maven Central](https://repo1.maven.org/maven2/.) to publish the [project
 See more details [here](docs/central.md).
 
 ### Maven
-If you use Maven, add the following dependencies for the core library:
-	
-    <dependency>
-        <groupId>com.github.smeup.reload</groupId>
-        <artifactId>reload</artifactId>
-        <version>development-SNAPSHOT</version>
-    </dependency>
+If you use Maven and if you want to work with sql and no-sql, add the following dependencies:
+
+        <dependency>
+            <groupId>io.github.smeup.reload</groupId>
+            <artifactId>base</artifactId>
+            <version>vx.y.z</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.smeup.reload</groupId>
+            <artifactId>manager</artifactId>
+            <version>vx.y.z</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.smeup.reload</groupId>
+            <artifactId>sql</artifactId>
+            <version>vx.y.z</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.smeup.reload</groupId>
+            <artifactId>nosql</artifactId>
+            <version>vx.y.z</version>
+        </dependency>
 
 ### Gradle
-Here are the configurationd to add to your build.gradle:
+The gradle configuration could be like this:
 ```
 dependencies {
     ...
-    implementation 'com.github.smeup:reload:-SNAPSHOT'
+    implementation "io.github.smeup.reload:base:vx.y.z"
+    implementation "io.github.smeup.reload:manager:vx.y.z"
+    implementation "io.github.smeup.reload:sql:vx.y.z"
+    implementation "io.github.smeup.reload:nosql:vx.y.z"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,23 @@
 				</plugins>
 			</build>
 		</profile>
+
+		<profile>
+			<id>reload-nexus-deploy</id>
+			<distributionManagement>
+				<repository>
+					<id>releases</id>
+					<name>Internal Releases</name>
+					<url>https://repo.smeup.cloud/nexus/content/repositories/releases</url>
+				</repository>
+
+				<snapshotRepository>
+					<id>snapshots</id>
+					<name>Internal Snapshots</name>
+					<url>https://repo.smeup.cloud/nexus/content/repositories/snapshots</url>
+				</snapshotRepository>
+			</distributionManagement>
+		</profile>
 	</profiles>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,16 @@
 	<profiles>
 		<profile>
 			<id>ci-cd</id>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+				<repository>
+					<id>ossrh</id>
+					<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+				</repository>
+			</distributionManagement>
 			<build>
 				<plugins>
 					<plugin>
@@ -219,34 +229,20 @@
 				</plugins>
 			</build>
 		</profile>
-
-		<profile>
-			<id>reload-nexus-deploy</id>
-			<distributionManagement>
-				<repository>
-					<id>releases</id>
-					<name>Internal Releases</name>
-					<url>https://repo.smeup.cloud/nexus/content/repositories/releases</url>
-				</repository>
-
-				<snapshotRepository>
-					<id>snapshots</id>
-					<name>Internal Snapshots</name>
-					<url>https://repo.smeup.cloud/nexus/content/repositories/snapshots</url>
-				</snapshotRepository>
-			</distributionManagement>
-		</profile>
 	</profiles>
 
 	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
 		<repository>
-			<id>ossrh</id>
-			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+			<id>releases</id>
+			<name>Internal Releases</name>
+			<url>https://repo.smeup.cloud/nexus/content/repositories/releases</url>
 		</repository>
+
+		<snapshotRepository>
+			<id>snapshots</id>
+			<name>Internal Snapshots</name>
+			<url>https://repo.smeup.cloud/nexus/content/repositories/snapshots</url>
+		</snapshotRepository>
 	</distributionManagement>
 
 </project>


### PR DESCRIPTION
Added a new action, triggered on "master" and "develop" branches merging, which publishes reload to internal smeup nexus.

 - It uses the _snapshots_ and _releases_ serverids, as set in `.m2/settings.xml`, in compliant to smeup internal artifacts distribution
 - You  can deploy to internal nexus through these commands: `mvn deploy -DskipTests` 