### PR TITLE
Example of Mock DBMManager implementation.

### DIFF
--- a/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileFactory.kt
+++ b/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileFactory.kt
@@ -125,7 +125,7 @@ private fun createDBManager(config: ConnectionConfig, logger: Logger? = null): D
 
 private fun getImplByUrl(config: ConnectionConfig) : String {
     return when {
-        config.impl != null && config.impl!!.trim().isEmpty() -> config.impl!!
+        config.impl != null && config.impl!!.trim().isNotEmpty() -> config.impl!!
         config.url.startsWith("jdbc:") -> "com.smeup.dbnative.sql.SQLDBMManager"
         config.url.startsWith("mongodb:") -> "com.smeup.dbnative.nosql.NoSQLDBMManager"
         config.url.startsWith("as400:") -> "com.smeup.dbnative.jt400.JT400DBMMAnager"

--- a/manager/src/test/kotlin/com/smeup/dbnative/manager/MockDBMManagerTest.kt
+++ b/manager/src/test/kotlin/com/smeup/dbnative/manager/MockDBMManagerTest.kt
@@ -28,7 +28,6 @@ private val MOCK_METADATA = FileMetadata(
 class MockDBManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {
 
     override fun validateConfig() {
-        connectionConfig.url.startsWith("test:")
     }
 
     override fun close() {

--- a/manager/src/test/kotlin/com/smeup/dbnative/manager/MockDBMManagerTest.kt
+++ b/manager/src/test/kotlin/com/smeup/dbnative/manager/MockDBMManagerTest.kt
@@ -1,0 +1,191 @@
+package com.smeup.dbnative.manager
+
+import com.smeup.dbnative.ConnectionConfig
+import com.smeup.dbnative.DBManagerBaseImpl
+import com.smeup.dbnative.DBNativeAccessConfig
+import com.smeup.dbnative.file.DBFile
+import com.smeup.dbnative.file.Record
+import com.smeup.dbnative.file.Result
+import com.smeup.dbnative.log.Logger
+import com.smeup.dbnative.model.Field
+import com.smeup.dbnative.model.FileMetadata
+import kotlin.test.Test
+import kotlin.test.fail
+
+private val MOCK_METADATA = FileMetadata(
+    name = "mock",
+    tableName = "mock",
+    fields = listOf(
+        Field("field1"),
+        Field("field2"),
+    ),
+    fileKeys = listOf("field1")
+)
+
+/**
+ * Mock implementation of DBManagerBaseImpl
+ */
+class MockDBManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {
+
+    override fun validateConfig() {
+        connectionConfig.url.startsWith("test:")
+    }
+
+    override fun close() {
+    }
+
+    override fun openFile(name: String) = MockDBFile()
+
+    override fun closeFile(name: String) {
+    }
+}
+
+/**
+ * Mock implementation of DBFile.
+ * All methods are not implemented.
+ */
+class MockDBFile(override var name: String, override var fileMetadata: FileMetadata, override var logger: Logger?) :
+    DBFile {
+
+    constructor() : this(
+        "mock",
+        MOCK_METADATA,
+        null
+    )
+
+    override fun eof(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun equal(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setll(key: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setll(keys: List<String>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setgt(key: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setgt(keys: List<String>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun chain(key: String): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun chain(keys: List<String>): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun read(): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readPrevious(): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readEqual(): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readEqual(key: String): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readEqual(keys: List<String>): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readPreviousEqual(): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readPreviousEqual(key: String): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun readPreviousEqual(keys: List<String>): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun write(record: Record): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(record: Record): Result {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(record: Record): Result {
+        TODO("Not yet implemented")
+    }
+}
+
+class MockDBMManagerTest {
+
+    /***
+     * Test that the mock: protocol is not handled for default
+     */
+    @Test
+    fun testMockProtocolNotHandled() {
+        val connectionConfig = ConnectionConfig(
+            fileName = "*",
+            url = "mock:",
+            user = "*",
+            password = "*"
+        )
+        val nativeAccessConfig = DBNativeAccessConfig(connectionsConfig = listOf(connectionConfig))
+        DBFileFactory(nativeAccessConfig).use { dbFileFactory ->
+            runCatching {
+                dbFileFactory.open(fileName = "mock", fileMetadata = MOCK_METADATA)
+            }.onSuccess {
+                fail("Should not be able to open a file because the mock: protocol is not handled")
+            }.onFailure {
+                assert(it is IllegalArgumentException)
+                assert(it.message == "mock: not handled")
+            }
+        }
+    }
+
+    /***
+     * Test that the mock: protocol is handled by passing a custom implementation in the ConnectionConfig.impl
+     * property
+     */
+    @Test
+    fun testMockProtocolHandled() {
+        // I say that
+        // - all the files (fileName = "*")
+        // - with the mock: protocol (url = "mock:")
+        // - with any user and password
+        // - will be managed by the MockDBManager class
+        val connectionConfig = ConnectionConfig(
+            fileName = "*",
+            url = "mock:",
+            user = "*",
+            password = "*",
+            impl = MockDBManager::class.java.name
+        )
+        val nativeAccessConfig =
+            DBNativeAccessConfig(connectionsConfig = listOf(connectionConfig))
+        DBFileFactory(nativeAccessConfig).use { dbFileFactory ->
+            val dbFile = dbFileFactory.open(fileName = "mock", fileMetadata = MOCK_METADATA)
+            kotlin.runCatching {
+                dbFile.eof()
+            }.onSuccess {
+                fail("Should not be able to call eof")
+            }.onFailure {
+                assert(it is NotImplementedError)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Reload allows externalization of the `DBMManager` implementation through the `ConnectionConfig.impl` property.

Given these requirements:
- My mocked `DBMManager` implementation must handle all files for the protocol URL: `mock:`
- My mocked `DBMManager` implementation must retrieve an instance of a mocked `DBFile` for each file name.
- All methods of my mocked `DBFile` implementation must throw a `NotImplementedError`.

# Example

## Mock DBMManager
```kotlin
/**
 * Mock implementation of DBManagerBaseImpl
 */
class MockDBManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {

    override fun validateConfig() {
    }

    override fun close() {
    }

    override fun openFile(name: String) = MockDBFile()

    override fun closeFile(name: String) {
    }
}

```

## Mock DBFile
```kotlin
/**
 * Mock implementation of DBFile.
 * All methods are not implemented.
 */
class MockDBFile(override var name: String, override var fileMetadata: FileMetadata, override var logger: Logger?) :
    DBFile {

    constructor() : this(
        "mock",
        MOCK_METADATA,
        null
    )

    override fun eof(): Boolean {
        TODO("Not yet implemented")
    }
    ...
}
```

## Create config and work with mocked DBFile

```kotlin
// I say that
// - all the files (fileName = "*")
// - with the mock: protocol (url = "mock:")
// - with any user and password
// - will be managed by the MockDBManager class
val connectionConfig = ConnectionConfig(
    fileName = "*",
    url = "mock:",
    user = "*",
    password = "*",
    impl = MockDBManager::class.java.name
)

// Create a configuration with the connectionConfig
val nativeAccessConfig =
    DBNativeAccessConfig(connectionsConfig = listOf(connectionConfig))

// Create a DBFileFactory with the configuration
DBFileFactory(nativeAccessConfig).use { dbFileFactory -> 
    // Open the file named `mock`
    val dbFile = dbFileFactory.open(fileName = "mock", fileMetadata = MOCK_METADATA)
    // Work with the file
    dbFile.setll("key")
    dbFile.read()
}
```