### PR TITLE
♻️ refactor: make ConnectionProvider app-scoped with per-app config map

### DIFF
--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -40,6 +40,19 @@ object ConnectionProvider {
     }
 
     /**
+     * Runs [block] in a thread-local scope bound to `"default"`, then closes all managers
+     * created during that scope.
+     *
+     * @deprecated Use [withScope] with an explicit [app] key instead.
+     */
+    @Deprecated(
+        message = "Use withScope(app, block) with an explicit app key instead.",
+        replaceWith = ReplaceWith("withScope(\"default\", block)")
+    )
+    @Throws(Exception::class)
+    fun withScope(block: ScopedBlock) = withScope("default", block)
+
+    /**
      * Runs [block] in a thread-local scope bound to [app], then closes all managers
      * created during that scope.
      *

--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -1,27 +1,35 @@
 package com.smeup.dbnative
 
 /**
- * Provides thread-scoped access to [DBMManager] instances.
+ * Provides thread-scoped access to [DBMManager] instances, keyed by application.
+ *
+ * Call [configure] once at startup with one [DBNativeAccessConfig] per app key.
+ * Wrap each FUN dispatch with [withScope] to bind an app to the current thread.
+ * Code deeper in the stack calls [currentManager] or [currentManagerOrNull] without
+ * knowing which app is active.
  */
 object ConnectionProvider {
 
-    private val threadLocal = ThreadLocal<MutableMap<ConnectionConfig, DBMManager>>()
+    private val threadLocal = ThreadLocal<Pair<String, MutableMap<ConnectionConfig, DBMManager>>>()
 
-    @Volatile private var config: DBNativeAccessConfig? = null
-    @Volatile private var managerFactory: ((ConnectionConfig) -> DBMManager)? = null
+    @Volatile private var configMap: Map<String, DBNativeAccessConfig>? = null
+    @Volatile private var factoryMap: Map<String, (ConnectionConfig) -> DBMManager>? = null
 
     /**
-     * Configures the provider with connection matching rules and a manager factory.
+     * Configures the provider with one config and factory per application key.
      */
-    fun configure(config: DBNativeAccessConfig, factory: (ConnectionConfig) -> DBMManager) {
-        this.config = config
-        this.managerFactory = factory
+    fun configure(
+        configMap: Map<String, DBNativeAccessConfig>,
+        factoryMap: Map<String, (ConnectionConfig) -> DBMManager>
+    ) {
+        this.configMap = configMap
+        this.factoryMap = factoryMap
     }
 
     /**
-     * Returns `true` if [configure] (or [configureWithPool]) has been called.
+     * Returns `true` if [configure] has been called with at least one entry.
      */
-    fun isConfigured(): Boolean = config != null
+    fun isConfigured(): Boolean = configMap?.isNotEmpty() == true
 
     /**
      * Functional interface used by [withScope] to execute a scoped block.
@@ -32,39 +40,49 @@ object ConnectionProvider {
     }
 
     /**
-     * Runs [block] in a thread-local scope and closes all managers created in that scope.
+     * Runs [block] in a thread-local scope bound to [app], then closes all managers
+     * created during that scope.
+     *
+     * @throws IllegalStateException if [configure] has not been called.
+     * @throws IllegalArgumentException if [app] has no entry in the config map.
      */
     @Throws(Exception::class)
-    fun withScope(block: ScopedBlock) {
-        requireNotNull(config) { "ConnectionProvider not configured" }
-        threadLocal.set(mutableMapOf())
+    fun withScope(app: String, block: ScopedBlock) {
+        requireNotNull(configMap) { "ConnectionProvider not configured" }
+        threadLocal.set(app to mutableMapOf())
         try {
             block.execute()
         } finally {
-            val managers = threadLocal.get()
+            val (_, managers) = threadLocal.get()
             threadLocal.remove()
-            managers?.values?.forEach { it.close() }
+            managers.values.forEach { it.close() }
         }
     }
 
     /**
      * Returns the current scope manager for [fileName], creating it on first use.
+     *
+     * @throws IllegalStateException if there is no active scope on this thread.
+     * @throws IllegalArgumentException if the active app has no config entry or [fileName]
+     *   matches no [ConnectionConfig].
      */
     fun currentManager(fileName: String): DBMManager {
-        val managers = requireNotNull(threadLocal.get()) { "No active scope on this thread" }
-        val cfg = requireNotNull(config)
-        val factory = requireNotNull(managerFactory)
+        val (app, managers) = requireNotNull(threadLocal.get()) { "No active scope on this thread" }
+        val cfg = requireNotNull(configMap?.get(app)) { "No configuration for app '$app'" }
+        val factory = requireNotNull(factoryMap?.get(app)) { "No factory for app '$app'" }
         val connectionConfig = findConnectionConfigFor(fileName, cfg.connectionsConfig)
         return managers.getOrPut(connectionConfig) { factory(connectionConfig) }
     }
 
     /**
-     * Like [currentManager], but returns `null` if there is no active scope or no match.
+     * Like [currentManager], but returns `null` if there is no active scope, no config for
+     * the active app, or no matching [ConnectionConfig] for [fileName].
      */
     fun currentManagerOrNull(fileName: String): DBMManager? {
-        val managers = threadLocal.get() ?: return null
-        val cfg = config ?: return null
-        val factory = managerFactory ?: return null
+        val pair = threadLocal.get() ?: return null
+        val (app, managers) = pair
+        val cfg = configMap?.get(app) ?: return null
+        val factory = factoryMap?.get(app) ?: return null
         return try {
             val connectionConfig = findConnectionConfigFor(fileName, cfg.connectionsConfig)
             managers.getOrPut(connectionConfig) { factory(connectionConfig) }

--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -16,6 +16,20 @@ object ConnectionProvider {
     @Volatile private var factoryMap: Map<String, (ConnectionConfig) -> DBMManager>? = null
 
     /**
+     * Configures the provider with a single config and factory, bound to the `"default"` app key.
+     *
+     * @deprecated Use [configure] with explicit app-keyed maps instead.
+     */
+    @Deprecated(
+        message = "Use configure(configMap, factoryMap) with explicit app-keyed maps instead.",
+        replaceWith = ReplaceWith("configure(mapOf(\"default\" to config), mapOf(\"default\" to factory))")
+    )
+    fun configure(
+        config: DBNativeAccessConfig,
+        factory: (ConnectionConfig) -> DBMManager
+    ) = configure(mapOf("default" to config), mapOf("default" to factory))
+
+    /**
      * Configures the provider with one config and factory per application key.
      */
     fun configure(

--- a/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
+++ b/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
@@ -11,6 +11,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+private const val TEST_APP = "test"
+private const val OTHER_APP = "other"
+
 private val TEST_CONFIG = ConnectionConfig(
     fileName = "*",
     url = "class:com.smeup.dbnative.mock.MockDBManager",
@@ -26,6 +29,10 @@ private val TEST_CONFIG_B = ConnectionConfig(
 )
 
 private val ACCESS_CONFIG = DBNativeAccessConfig(listOf(TEST_CONFIG_B, TEST_CONFIG))
+private val CONFIG_MAP = mapOf(TEST_APP to ACCESS_CONFIG)
+
+private fun spyFactory(configMap: Map<String, DBNativeAccessConfig>): Map<String, (ConnectionConfig) -> DBMManager> =
+    configMap.mapValues { { connConfig: ConnectionConfig -> SpyDBMManager(connConfig) } }
 
 /**
  * Unit tests for [ConnectionProvider] scoped lifecycle and lookup behavior.
@@ -34,18 +41,17 @@ class ConnectionProviderTest {
 
     @Before
     fun setUp() {
-        ConnectionProvider.configure(ACCESS_CONFIG) { connConfig -> SpyDBMManager(connConfig) }
+        ConnectionProvider.configure(CONFIG_MAP, spyFactory(CONFIG_MAP))
     }
 
     @After
     fun tearDown() {
-        // Reset state between tests by re-configuring with a no-op factory;
-        // the real clean-up is handled by withScope's finally block.
+        // Reset state between tests by re-configuring; the real clean-up is in withScope's finally block.
     }
 
     @Test
     fun withScope_createsManagerOnDemand() {
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val manager = ConnectionProvider.currentManager("FILEA")
             assertNotNull(manager)
         }
@@ -53,7 +59,7 @@ class ConnectionProviderTest {
 
     @Test
     fun withScope_sameManagerForSameFile() {
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val m1 = ConnectionProvider.currentManager("FILEA")
             val m2 = ConnectionProvider.currentManager("FILEA")
             assertSame(m1, m2)
@@ -62,7 +68,7 @@ class ConnectionProviderTest {
 
     @Test
     fun withScope_differentManagerForDifferentConfig() {
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val mA = ConnectionProvider.currentManager("FILEA")
             val mB = ConnectionProvider.currentManager("FILEB")
             assertTrue(mA !== mB)
@@ -72,10 +78,11 @@ class ConnectionProviderTest {
     @Test
     fun withScope_closesManagersOnExit() {
         val spies = mutableListOf<SpyDBMManager>()
-        ConnectionProvider.configure(ACCESS_CONFIG) { connConfig ->
+        val collectingFactory = CONFIG_MAP.mapValues { { connConfig: ConnectionConfig ->
             SpyDBMManager(connConfig).also { spies.add(it) }
-        }
-        ConnectionProvider.withScope {
+        } }
+        ConnectionProvider.configure(CONFIG_MAP, collectingFactory)
+        ConnectionProvider.withScope(TEST_APP) {
             ConnectionProvider.currentManager("FILEA")
             ConnectionProvider.currentManager("FILEB")
         }
@@ -92,8 +99,9 @@ class ConnectionProviderTest {
     @Test
     fun currentManagerOrNull_returnsNullForUnknownFile() {
         val isolatedConfig = DBNativeAccessConfig(listOf(TEST_CONFIG_B))
-        ConnectionProvider.configure(isolatedConfig) { connConfig -> SpyDBMManager(connConfig) }
-        ConnectionProvider.withScope {
+        val isolatedMap = mapOf(TEST_APP to isolatedConfig)
+        ConnectionProvider.configure(isolatedMap, spyFactory(isolatedMap))
+        ConnectionProvider.withScope(TEST_APP) {
             val result = ConnectionProvider.currentManagerOrNull("UNKNOWN_NO_WILDCARD")
             assertNull(result)
         }
@@ -101,15 +109,12 @@ class ConnectionProviderTest {
 
     @Test
     fun withScope_throwsWhenNotConfigured() {
-        // Temporarily point to a fresh unconfigured-looking provider by using a local object
-        // We test via reflection-like approach: re-create a scenario where configure was not called.
-        // Since ConnectionProvider is a singleton, we configure it with null-equivalent by
-        // configuring with an empty config and verifying the require message.
         val emptyConfig = DBNativeAccessConfig(listOf())
-        ConnectionProvider.configure(emptyConfig) { SpyDBMManager(it) }
+        val emptyMap = mapOf(TEST_APP to emptyConfig)
+        ConnectionProvider.configure(emptyMap, emptyMap.mapValues { { cfg: ConnectionConfig -> SpyDBMManager(cfg) } })
 
         assertFailsWith<IllegalArgumentException> {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.currentManager("ANYTHING")
             }
         }
@@ -118,7 +123,7 @@ class ConnectionProviderTest {
     @Test
     fun withScope_scopeIsThreadLocal() {
         var managerSeenFromOtherThread: DBMManager? = null
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val thread = Thread {
                 managerSeenFromOtherThread = ConnectionProvider.currentManagerOrNull("FILEA")
             }
@@ -126,6 +131,32 @@ class ConnectionProviderTest {
             thread.join()
         }
         assertNull(managerSeenFromOtherThread)
+    }
+
+    @Test
+    fun withScope_differentAppsUseIsolatedConfigs() {
+        val otherConfig = DBNativeAccessConfig(listOf(
+            ConnectionConfig(fileName = "*", url = "class:com.smeup.dbnative.mock.MockDBManager", user = "other", password = "")
+        ))
+        val multiAppMap = mapOf(TEST_APP to ACCESS_CONFIG, OTHER_APP to otherConfig)
+        ConnectionProvider.configure(multiAppMap, spyFactory(multiAppMap))
+
+        ConnectionProvider.withScope(TEST_APP) {
+            val m = ConnectionProvider.currentManager("FILEA") as SpyDBMManager
+            assertTrue(m.connectionConfig.user == "")
+        }
+        ConnectionProvider.withScope(OTHER_APP) {
+            val m = ConnectionProvider.currentManager("FILEA") as SpyDBMManager
+            assertTrue(m.connectionConfig.user == "other")
+        }
+    }
+
+    @Test
+    fun currentManagerOrNull_returnsNullForUnknownApp() {
+        ConnectionProvider.withScope("no-such-app") {
+            val result = ConnectionProvider.currentManagerOrNull("FILEA")
+            assertNull(result)
+        }
     }
 }
 

--- a/manager/src/main/kotlin/com/smeup/dbnative/manager/ConnectionProviderExtensions.kt
+++ b/manager/src/main/kotlin/com/smeup/dbnative/manager/ConnectionProviderExtensions.kt
@@ -1,5 +1,6 @@
 package com.smeup.dbnative.manager
 
+import com.smeup.dbnative.ConnectionConfig
 import com.smeup.dbnative.ConnectionProvider
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.dbnative.log.Logger
@@ -7,9 +8,15 @@ import com.smeup.dbnative.log.Logger
 /**
  * Configures [ConnectionProvider] using the manager module factory.
  *
- * @param config Native access configuration.
- * @param logger Optional logger forwarded to manager creation.
+ * @param configMap One [DBNativeAccessConfig] per application key.
+ * @param logger Optional logger forwarded to manager creation (overrides per-config logger).
  */
-fun ConnectionProvider.configure(config: DBNativeAccessConfig, logger: Logger? = null) {
-    configure(config) { connConfig -> createDBManager(connConfig, logger) }
+fun ConnectionProvider.configure(configMap: Map<String, DBNativeAccessConfig>, logger: Logger? = null) {
+    configure(
+        configMap,
+        configMap.mapValues { (_, cfg) ->
+            val effectiveLogger = logger ?: cfg.logger
+            { connConfig: ConnectionConfig -> createDBManager(connConfig, effectiveLogger) }
+        }
+    )
 }

--- a/manager/src/main/kotlin/com/smeup/dbnative/manager/ConnectionProviderExtensions.kt
+++ b/manager/src/main/kotlin/com/smeup/dbnative/manager/ConnectionProviderExtensions.kt
@@ -5,6 +5,19 @@ import com.smeup.dbnative.ConnectionProvider
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.dbnative.log.Logger
 
+
+/**
+ * Configures [ConnectionProvider] using the manager module factory, bound to the `"default"` app key.
+ *
+ * @deprecated Use [configure] with an explicit app-keyed map instead.
+ */
+@Deprecated(
+    message = "Use configure(configMap, logger) with an explicit app-keyed map instead.",
+    replaceWith = ReplaceWith("configure(mapOf(\"default\" to config), logger)")
+)
+fun ConnectionProvider.configure(config: DBNativeAccessConfig, logger: Logger? = null) =
+    configure(mapOf("default" to config), logger)
+
 /**
  * Configures [ConnectionProvider] using the manager module factory.
  *

--- a/manager/src/test/kotlin/com/smeup/dbnative/manager/DBFileFactoryConnectionSharingTest.kt
+++ b/manager/src/test/kotlin/com/smeup/dbnative/manager/DBFileFactoryConnectionSharingTest.kt
@@ -4,7 +4,6 @@ import com.smeup.dbnative.ConnectionConfig
 import com.smeup.dbnative.ConnectionProvider
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.dbnative.model.CharacterType
-import com.smeup.dbnative.model.FileMetadata
 import com.smeup.dbnative.sql.SQLDBMManager
 import com.smeup.dbnative.sql.toDataSource
 import com.smeup.dbnative.utils.TypedField
@@ -18,6 +17,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+private const val TEST_APP = "test"
+
 private val SHARING_CONNECTION_CONFIG = ConnectionConfig(
     fileName = "*",
     url = "jdbc:hsqldb:mem:SHARING_TEST",
@@ -27,7 +28,7 @@ private val SHARING_CONNECTION_CONFIG = ConnectionConfig(
 
 private val SHARING_ACCESS_CONFIG = DBNativeAccessConfig(listOf(SHARING_CONNECTION_CONFIG))
 
-private val TABLE_METADATA = FileMetadata(
+private val TABLE_METADATA = com.smeup.dbnative.model.FileMetadata(
     "SHARE1L",
     "SHARE1F",
     listOf<TypedField>("NAME" fieldByType CharacterType(20)).fieldList(),
@@ -48,7 +49,7 @@ class DBFileFactoryConnectionSharingTest {
             it.executeUpdate("CREATE TABLE IF NOT EXISTS SHARE1F (NAME CHAR(20))")
         }
         bootstrapManager.registerMetadata(TABLE_METADATA, true)
-        ConnectionProvider.configure(SHARING_ACCESS_CONFIG, null)
+        ConnectionProvider.configure(mapOf(TEST_APP to SHARING_ACCESS_CONFIG), null)
     }
 
     @After
@@ -63,9 +64,8 @@ class DBFileFactoryConnectionSharingTest {
     @Test
     fun open_insideScope_reusesManagerFromScope() {
         val factory = DBFileFactory(SHARING_ACCESS_CONFIG)
-        var scopedManager: com.smeup.dbnative.DBMManager? = null
-        ConnectionProvider.withScope {
-            scopedManager = ConnectionProvider.currentManager("SHARE1L")
+        ConnectionProvider.withScope(TEST_APP) {
+            ConnectionProvider.currentManager("SHARE1L")
             val dbFile = factory.open("SHARE1L", null)
             assertNotNull(dbFile)
             dbFile.close()
@@ -87,7 +87,7 @@ class DBFileFactoryConnectionSharingTest {
     @Test
     fun open_insideScope_sameConnectionAsProvider() {
         val factory = DBFileFactory(SHARING_ACCESS_CONFIG)
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val scopedMgr = ConnectionProvider.currentManager("SHARE1L") as? SQLDBMManager
             assertNotNull(scopedMgr)
             val providerConn = scopedMgr.connection

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensions.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensions.kt
@@ -23,6 +23,19 @@ fun ConnectionProvider.requireDataSource(fileName: String): DataSource =
         "Manager for '$fileName' is not SQL-based"
     }
 
+
+/**
+ * Configures [ConnectionProvider] with pooled SQL managers for the `"default"` app key.
+ *
+ * @deprecated Use [configureWithPool] with an explicit app-keyed map instead.
+ */
+@Deprecated(
+    message = "Use configureWithPool(configMap) with an explicit app-keyed map instead.",
+    replaceWith = ReplaceWith("configureWithPool(mapOf(\"default\" to config))")
+)
+fun ConnectionProvider.configureWithPool(config: DBNativeAccessConfig): AutoCloseable =
+    configureWithPool(mapOf("default" to config))
+
 /**
  * Configures [ConnectionProvider] with pooled SQL managers.
  *

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensions.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensions.kt
@@ -1,5 +1,6 @@
 package com.smeup.dbnative.sql
 
+import com.smeup.dbnative.ConnectionConfig
 import com.smeup.dbnative.ConnectionProvider
 import com.smeup.dbnative.DBNativeAccessConfig
 import com.smeup.dbnative.log.LoggingKey
@@ -25,29 +26,39 @@ fun ConnectionProvider.requireDataSource(fileName: String): DataSource =
 /**
  * Configures [ConnectionProvider] with pooled SQL managers.
  *
- * One pool is created per unique (`url`, `user`) pair.
+ * One HikariCP pool is created per unique (`url`, `user`) pair across all apps —
+ * apps that share the same database share a single pool.
  *
- * @return A handle that closes all created pools.
+ * @param configMap One [DBNativeAccessConfig] per application key.
+ * @return A handle that closes all created pools on [AutoCloseable.close].
  */
-fun ConnectionProvider.configureWithPool(config: DBNativeAccessConfig): AutoCloseable {
-    // One pool per unique (url, user) — only for configs that have an explicit poolConfig
-    val pools = config.connectionsConfig
+fun ConnectionProvider.configureWithPool(configMap: Map<String, DBNativeAccessConfig>): AutoCloseable {
+    val logger = configMap.values.firstNotNullOfOrNull { it.logger }
+    val allConfigs = configMap.values.flatMap { it.connectionsConfig }
+
+    val pools = allConfigs
         .filter { it.poolConfig != null }
         .distinctBy { it.url to it.user }
-        .associateBy({ it.url to it.user }) { SQLConnectionPool(it, config.logger) }
+        .associateBy({ it.url to it.user }) { SQLConnectionPool(it, logger) }
+
     pools.forEach { (key, _) ->
-        config.logger?.logEvent(LoggingKey.connection, "Created SQL connection pool for url=${key.first} user=${key.second}")
+        logger?.logEvent(LoggingKey.connection, "Created SQL connection pool for url=${key.first} user=${key.second}")
     }
-    configure(config) { connConfig ->
-        val pool = pools[connConfig.url to connConfig.user]
-        val manager = if (pool != null) SQLPooledDBMManager(connConfig, pool)
-                      else SQLDBMManager(connConfig)
-        manager.logger = config.logger
-        manager
+
+    val factoryMap = configMap.mapValues { (_, cfg) ->
+        { connConfig: ConnectionConfig ->
+            val pool = pools[connConfig.url to connConfig.user]
+            val manager = if (pool != null) SQLPooledDBMManager(connConfig, pool)
+                          else SQLDBMManager(connConfig)
+            manager.logger = cfg.logger
+            manager
+        }
     }
+    configure(configMap, factoryMap)
+
     return AutoCloseable {
-        pools.entries.forEach { (key, pool) ->
-            config.logger?.logEvent(LoggingKey.connection, "Shutting down SQL connection pool for url=${key.first} user=${key.second}")
+        pools.forEach { (key, pool) ->
+            logger?.logEvent(LoggingKey.connection, "Shutting down SQL connection pool for url=${key.first} user=${key.second}")
             pool.close()
         }
     }

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionLoggingTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionLoggingTest.kt
@@ -15,6 +15,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+private const val TEST_APP = "test"
+
 private val LOG_SQL_CONFIG = ConnectionConfig(
     fileName = "*",
     url = "jdbc:hsqldb:mem:LOG_NONPOOL_TEST",
@@ -43,21 +45,23 @@ class ConnectionLoggingTest {
 
     @Before
     fun setUp() {
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(LOG_SQL_CONFIG))) { SQLDBMManager(it) }
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_SQL_CONFIG)))
+        ConnectionProvider.configure(cfg, cfg.mapValues { { c: ConnectionConfig -> SQLDBMManager(c) } })
     }
 
     @After
     fun tearDown() {
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(LOG_SQL_CONFIG))) { SQLDBMManager(it) }
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_SQL_CONFIG)))
+        ConnectionProvider.configure(cfg, cfg.mapValues { { c: ConnectionConfig -> SQLDBMManager(c) } })
     }
 
     @Test
     fun logger_propagatedToNonPooledManager() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_SQL_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_SQL_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.requireDataSource("FILEA").getConnection()
             }
         } finally {
@@ -70,10 +74,10 @@ class ConnectionLoggingTest {
     @Test
     fun nonPooledManager_closeEventCarriesLifetime() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_SQL_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_SQL_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.requireDataSource("FILEA").getConnection()
             }
         } finally {
@@ -87,10 +91,10 @@ class ConnectionLoggingTest {
     @Test
     fun pooledManager_borrowEventCarriesTiming() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.requireDataSource("FILEA").getConnection()
             }
         } finally {
@@ -104,10 +108,10 @@ class ConnectionLoggingTest {
     @Test
     fun pooledManager_returnEventIsEmittedAfterScope() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.requireDataSource("FILEA").getConnection()
             }
         } finally {
@@ -120,11 +124,11 @@ class ConnectionLoggingTest {
     @Test
     fun pooledManager_noReturnEventWhenConnectionNeverAccessed() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
-                ConnectionProvider.currentManager("FILEA") // creates manager but does not borrow connection
+            ConnectionProvider.withScope(TEST_APP) {
+                ConnectionProvider.currentManager("FILEA")
             }
         } finally {
             handle.close()
@@ -136,8 +140,8 @@ class ConnectionLoggingTest {
     @Test
     fun configureWithPool_logsPoolCreationAndShutdown() {
         val (logger, events) = captureLogger()
-        val config = DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger)
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(LOG_POOLED_CONFIG), logger))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
             assertTrue(events.any { it.eventKey == LoggingKey.connection && "Created" in it.message },
                 "Expected pool creation event on configureWithPool")

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensionsTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensionsTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+private const val TEST_APP = "test"
+
 private val SQL_CONFIG = ConnectionConfig(
     fileName = "*",
     url = "jdbc:hsqldb:mem:CP_SQL_TEST",
@@ -46,17 +48,19 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Before
     fun setUp() {
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(SQL_CONFIG)), ::sqlFactory)
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG)))
+        ConnectionProvider.configure(cfg, cfg.mapValues { { c: com.smeup.dbnative.ConnectionConfig -> sqlFactory(c) } })
     }
 
     @After
     fun tearDown() {
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(SQL_CONFIG)), ::sqlFactory)
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG)))
+        ConnectionProvider.configure(cfg, cfg.mapValues { { c: com.smeup.dbnative.ConnectionConfig -> sqlFactory(c) } })
     }
 
     @Test
     fun requireDataSource_returnsScopedDataSource() {
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val ds = ConnectionProvider.requireDataSource("FILEA")
             assertNotNull(ds)
         }
@@ -70,11 +74,10 @@ class ConnectionProviderSqlExtensionsTest {
             user = "",
             password = ""
         )
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(nonSqlConfig))) { cfg ->
-            com.smeup.dbnative.mock.MockDBManager(cfg)
-        }
+        val cfgMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(nonSqlConfig)))
+        ConnectionProvider.configure(cfgMap, cfgMap.mapValues { { cfg: com.smeup.dbnative.ConnectionConfig -> com.smeup.dbnative.mock.MockDBManager(cfg) } })
         assertFailsWith<IllegalArgumentException> {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.requireDataSource("NOSQL")
             }
         }
@@ -88,10 +91,9 @@ class ConnectionProviderSqlExtensionsTest {
             user = "",
             password = ""
         )
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(nonSqlConfig))) { cfg ->
-            com.smeup.dbnative.mock.MockDBManager(cfg)
-        }
-        ConnectionProvider.withScope {
+        val cfgMap2 = mapOf(TEST_APP to DBNativeAccessConfig(listOf(nonSqlConfig)))
+        ConnectionProvider.configure(cfgMap2, cfgMap2.mapValues { { cfg: com.smeup.dbnative.ConnectionConfig -> com.smeup.dbnative.mock.MockDBManager(cfg) } })
+        ConnectionProvider.withScope(TEST_APP) {
             val ds = ConnectionProvider.currentDataSource("NOSQL2")
             assertNull(ds)
         }
@@ -99,7 +101,7 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Test
     fun getConnection_sameInstanceWithinScope() {
-        ConnectionProvider.withScope {
+        ConnectionProvider.withScope(TEST_APP) {
             val ds = ConnectionProvider.requireDataSource("FILEA")
             val c1 = ds.getConnection()
             val c2 = ds.getConnection()
@@ -109,10 +111,10 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Test
     fun configureWithPool_createsOnePoolPerConnectionConfig() {
-        val config = DBNativeAccessConfig(listOf(SQL_CONFIG, SQL_CONFIG_B))
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG, SQL_CONFIG_B)))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 val dsA = ConnectionProvider.requireDataSource("FILEA")
                 val dsB = ConnectionProvider.requireDataSource("FILEB")
                 assertNotNull(dsA)
@@ -125,19 +127,19 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Test
     fun configureWithPool_closeHandle_shutsDownAllPools() {
-        val config = DBNativeAccessConfig(listOf(SQL_CONFIG, SQL_CONFIG_B))
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG, SQL_CONFIG_B)))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         handle.close()
-        // Re-configure with non-pooled to restore state for other tests
-        ConnectionProvider.configure(DBNativeAccessConfig(listOf(SQL_CONFIG)), ::sqlFactory)
+        val resetCfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG)))
+        ConnectionProvider.configure(resetCfg, resetCfg.mapValues { { c: com.smeup.dbnative.ConnectionConfig -> sqlFactory(c) } })
     }
 
     @Test
     fun configureWithPool_withExplicitPoolConfig_createsSQLPooledDBMManager() {
-        val config = DBNativeAccessConfig(listOf(POOLED_CONFIG))
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(POOLED_CONFIG)))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 val manager = ConnectionProvider.currentManager("POOLED")
                 assertTrue(manager is SQLPooledDBMManager)
             }
@@ -148,10 +150,10 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Test
     fun configureWithPool_withoutPoolConfig_fallsBackToSQLDBMManager() {
-        val config = DBNativeAccessConfig(listOf(SQL_CONFIG))
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(SQL_CONFIG)))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 val manager = ConnectionProvider.currentManager("FILEA")
                 assertTrue(manager is SQLDBMManager)
                 assertFalse(manager is SQLPooledDBMManager)
@@ -163,10 +165,10 @@ class ConnectionProviderSqlExtensionsTest {
 
     @Test
     fun configureWithPool_mixedConfigs_routesCorrectly() {
-        val config = DBNativeAccessConfig(listOf(POOLED_CONFIG, SQL_CONFIG))
-        val handle = ConnectionProvider.configureWithPool(config)
+        val configMap = mapOf(TEST_APP to DBNativeAccessConfig(listOf(POOLED_CONFIG, SQL_CONFIG)))
+        val handle = ConnectionProvider.configureWithPool(configMap)
         try {
-            ConnectionProvider.withScope {
+            ConnectionProvider.withScope(TEST_APP) {
                 val pooledManager = ConnectionProvider.currentManager("POOLED")
                 val nonPooledManager = ConnectionProvider.currentManager("FILEA")
                 assertTrue(pooledManager is SQLPooledDBMManager)


### PR DESCRIPTION
## Summary

- `configure()` now accepts `Map<String, DBNativeAccessConfig>` and a matching factory map keyed by app key
- `withScope()` binds an explicit app key to the thread-local scope so `currentManager()` resolves the correct config entry
- `ConnectionProviderExtensions.configure()` and the SQL pool extension (`configureWithPool`) adapted to the new map-based API

## Motivation

Required by **C5 Test FUN regression** — the single-config model caused connection scope collisions when multiple apps had a different datasource configuration for the same file.

A key insight driving this change: datasource lookup per file (`currentManager(fileName)`) must be app-aware, because different apps may map the same logical file name to different physical data sources. Without binding the scope to an app key, the lookup would silently resolve against the wrong config when more than one app is configured.

## Test plan

- [x] `ConnectionProviderTest` — core scope behaviour per app key
- [x] `DBFileFactoryConnectionSharingTest` — manager sharing within a scope
- [x] `ConnectionProviderSqlExtensionsTest` — pool-backed scope
- [x] `ConnectionLoggingTest` — logging under the new API