### PR TITLE
Add isScopeActive() query to ConnectionProvider

### DIFF
--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -46,6 +46,11 @@ object ConnectionProvider {
     fun isConfigured(): Boolean = configMap?.isNotEmpty() == true
 
     /**
+     * Returns `true` if a scope is currently active on this thread.
+     */
+    fun isScopeActive(): Boolean = threadLocal.get() != null
+
+    /**
      * Functional interface used by [withScope] to execute a scoped block.
      */
     fun interface ScopedBlock {

--- a/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
+++ b/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
@@ -6,6 +6,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -117,6 +118,18 @@ class ConnectionProviderTest {
             ConnectionProvider.withScope(TEST_APP) {
                 ConnectionProvider.currentManager("ANYTHING")
             }
+        }
+    }
+
+    @Test
+    fun isScopeActive_falseOutsideScope() {
+        assertFalse(ConnectionProvider.isScopeActive())
+    }
+
+    @Test
+    fun isScopeActive_trueInsideScope() {
+        ConnectionProvider.withScope(TEST_APP) {
+            assertTrue(ConnectionProvider.isScopeActive())
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `isScopeActive(): Boolean` to `ConnectionProvider` — returns `true` if a thread-local scope is currently active on the calling thread
- Covers the new method with two unit tests (`isScopeActive_falseOutsideScope`, `isScopeActive_trueInsideScope`)

## Motivation

Callers that may run on either the scope-owner thread or a different thread (e.g. a debugger thread pool) need a way to check whether a scope is already present before deciding whether to call `withScope()`. Without this query, the only safe option is nesting, which corrupts the outer scope's manager map.

## Test plan

- [x] `ConnectionProviderTest` passes (all existing tests + 2 new)
- [x] No regression in downstream projects