### PR TITLE
feat: add provider-level logging to ConnectionProvider

### DIFF
--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -1,5 +1,7 @@
 package com.smeup.dbnative
 
+import com.smeup.dbnative.log.LoggingKey
+
 /**
  * Provides thread-scoped access to [DBMManager] instances, keyed by application.
  *
@@ -14,6 +16,9 @@ object ConnectionProvider {
 
     @Volatile private var configMap: Map<String, DBNativeAccessConfig>? = null
     @Volatile private var factoryMap: Map<String, (ConnectionConfig) -> DBMManager>? = null
+
+    private fun loggerFor(app: String) = configMap?.get(app)?.logger
+    private fun anyLogger() = configMap?.values?.firstNotNullOfOrNull { it.logger }
 
     /**
      * Configures the provider with a single config and factory, bound to the `"default"` app key.
@@ -38,6 +43,7 @@ object ConnectionProvider {
     ) {
         this.configMap = configMap
         this.factoryMap = factoryMap
+        anyLogger()?.logEvent(LoggingKey.provider, "ConnectionProvider configured with apps: ${configMap.keys}")
     }
 
     /**
@@ -81,12 +87,15 @@ object ConnectionProvider {
     @Throws(Exception::class)
     fun withScope(app: String, block: ScopedBlock) {
         requireNotNull(configMap) { "ConnectionProvider not configured" }
+        val logger = loggerFor(app)
+        logger?.logEvent(LoggingKey.provider, "Scope opened for app '$app'")
         threadLocal.set(app to mutableMapOf())
         try {
             block.execute()
         } finally {
             val (_, managers) = threadLocal.get()
             threadLocal.remove()
+            logger?.logEvent(LoggingKey.provider, "Scope closed for app '$app', closing ${managers.size} manager(s)")
             managers.values.forEach { it.close() }
         }
     }
@@ -103,7 +112,10 @@ object ConnectionProvider {
         val cfg = requireNotNull(configMap?.get(app)) { "No configuration for app '$app'" }
         val factory = requireNotNull(factoryMap?.get(app)) { "No factory for app '$app'" }
         val connectionConfig = findConnectionConfigFor(fileName, cfg.connectionsConfig)
-        return managers.getOrPut(connectionConfig) { factory(connectionConfig) }
+        val isNew = !managers.containsKey(connectionConfig)
+        return managers.getOrPut(connectionConfig) { factory(connectionConfig) }.also {
+            if (isNew) loggerFor(app)?.logEvent(LoggingKey.provider, "Created manager for '$fileName' (app '$app')")
+        }
     }
 
     /**
@@ -117,7 +129,10 @@ object ConnectionProvider {
         val factory = factoryMap?.get(app) ?: return null
         return try {
             val connectionConfig = findConnectionConfigFor(fileName, cfg.connectionsConfig)
-            managers.getOrPut(connectionConfig) { factory(connectionConfig) }
+            val isNew = !managers.containsKey(connectionConfig)
+            managers.getOrPut(connectionConfig) { factory(connectionConfig) }.also {
+                if (isNew) loggerFor(app)?.logEvent(LoggingKey.provider, "Created manager for '$fileName' (app '$app')")
+            }
         } catch (e: IllegalArgumentException) {
             null
         }

--- a/base/src/main/kotlin/com/smeup/dbnative/log/Logging.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/log/Logging.kt
@@ -13,7 +13,8 @@ enum class LoggingKey(val level: LoggingLevel){
     execute_inquiry(LoggingLevel.DEBUG),
     search_data(LoggingLevel.DEBUG),
     connection(LoggingLevel.DEBUG),
-    performance_metric(LoggingLevel.DEBUG)
+    performance_metric(LoggingLevel.DEBUG),
+    provider(LoggingLevel.DEBUG)
 }
 
 enum class NativeMethod(){

--- a/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
+++ b/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
@@ -1,10 +1,15 @@
 package com.smeup.dbnative
 
 import com.smeup.dbnative.file.DBFile
+import com.smeup.dbnative.log.Logger
+import com.smeup.dbnative.log.LoggingEvent
+import com.smeup.dbnative.log.LoggingKey
+import com.smeup.dbnative.log.LoggingLevel
 import com.smeup.dbnative.model.FileMetadata
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -170,6 +175,45 @@ class ConnectionProviderTest {
             val result = ConnectionProvider.currentManagerOrNull("FILEA")
             assertNull(result)
         }
+    }
+
+    @Test
+    fun logging_configure_emits_provider_event() {
+        val events = mutableListOf<LoggingEvent>()
+        val logger = Logger(LoggingLevel.ALL) { events.add(it) }
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(TEST_CONFIG), logger))
+        ConnectionProvider.configure(cfg, spyFactory(cfg))
+        assertEquals(1, events.count { it.eventKey == LoggingKey.provider })
+        assertTrue(events.first { it.eventKey == LoggingKey.provider }.message.contains(TEST_APP))
+    }
+
+    @Test
+    fun logging_withScope_emits_open_and_close() {
+        val events = mutableListOf<LoggingEvent>()
+        val logger = Logger(LoggingLevel.ALL) { events.add(it) }
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(TEST_CONFIG), logger))
+        ConnectionProvider.configure(cfg, spyFactory(cfg))
+        events.clear()
+        ConnectionProvider.withScope(TEST_APP) { /* no-op */ }
+        val scopeEvents = events.filter { it.eventKey == LoggingKey.provider }
+        assertEquals(2, scopeEvents.size)
+        assertTrue(scopeEvents[0].message.contains("opened"))
+        assertTrue(scopeEvents[1].message.contains("closed"))
+    }
+
+    @Test
+    fun logging_currentManager_emits_on_first_use_only() {
+        val events = mutableListOf<LoggingEvent>()
+        val logger = Logger(LoggingLevel.ALL) { events.add(it) }
+        val cfg = mapOf(TEST_APP to DBNativeAccessConfig(listOf(TEST_CONFIG), logger))
+        ConnectionProvider.configure(cfg, spyFactory(cfg))
+        events.clear()
+        ConnectionProvider.withScope(TEST_APP) {
+            ConnectionProvider.currentManager("FILEA")
+            ConnectionProvider.currentManager("FILEA")
+        }
+        val creationEvents = events.filter { it.eventKey == LoggingKey.provider && it.message.contains("Created manager") }
+        assertEquals(1, creationEvents.size)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `LoggingKey.provider` (DEBUG level) to the logging enum
- Emits log events on `configure` (lists configured app keys), `withScope` (open/close with manager count), and first `currentManager` / `currentManagerOrNull` call per connection config
- Covers all three behaviours with unit tests in `ConnectionProviderTest`

## Test plan

- [x] `ConnectionProviderTest.logging_configure_emits_provider_event` — configure emits exactly one `provider` event containing the app name
- [x] `ConnectionProviderTest.logging_withScope_emits_open_and_close` — scope emits "opened" then "closed" events
- [x] `ConnectionProviderTest.logging_currentManager_emits_on_first_use_only` — manager-creation event fires once per connection config, not on cache hits
- [x] `mvn clean install -DskipTests` passes (verified locally)