### PR TITLE
feat: add generic executeQuery API to DBMManager

### DIFF
--- a/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/ConnectionProvider.kt
@@ -12,10 +12,10 @@ import com.smeup.dbnative.log.LoggingKey
  */
 object ConnectionProvider {
 
-    private val threadLocal = ThreadLocal<Pair<String, MutableMap<ConnectionConfig, DBMManager>>>()
+    private val threadLocal = ThreadLocal<Pair<String, MutableMap<ConnectionConfig, DBMManager<*, *>>>>()
 
     @Volatile private var configMap: Map<String, DBNativeAccessConfig>? = null
-    @Volatile private var factoryMap: Map<String, (ConnectionConfig) -> DBMManager>? = null
+    @Volatile private var factoryMap: Map<String, (ConnectionConfig) -> DBMManager<*, *>>? = null
 
     private fun loggerFor(app: String) = configMap?.get(app)?.logger
     private fun anyLogger() = configMap?.values?.firstNotNullOfOrNull { it.logger }
@@ -31,7 +31,7 @@ object ConnectionProvider {
     )
     fun configure(
         config: DBNativeAccessConfig,
-        factory: (ConnectionConfig) -> DBMManager
+        factory: (ConnectionConfig) -> DBMManager<*, *>
     ) = configure(mapOf("default" to config), mapOf("default" to factory))
 
     /**
@@ -39,7 +39,7 @@ object ConnectionProvider {
      */
     fun configure(
         configMap: Map<String, DBNativeAccessConfig>,
-        factoryMap: Map<String, (ConnectionConfig) -> DBMManager>
+        factoryMap: Map<String, (ConnectionConfig) -> DBMManager<*, *>>
     ) {
         this.configMap = configMap
         this.factoryMap = factoryMap
@@ -107,7 +107,7 @@ object ConnectionProvider {
      * @throws IllegalArgumentException if the active app has no config entry or [fileName]
      *   matches no [ConnectionConfig].
      */
-    fun currentManager(fileName: String): DBMManager {
+    fun currentManager(fileName: String): DBMManager<*, *> {
         val (app, managers) = requireNotNull(threadLocal.get()) { "No active scope on this thread" }
         val cfg = requireNotNull(configMap?.get(app)) { "No configuration for app '$app'" }
         val factory = requireNotNull(factoryMap?.get(app)) { "No factory for app '$app'" }
@@ -122,7 +122,7 @@ object ConnectionProvider {
      * Like [currentManager], but returns `null` if there is no active scope, no config for
      * the active app, or no matching [ConnectionConfig] for [fileName].
      */
-    fun currentManagerOrNull(fileName: String): DBMManager? {
+    fun currentManagerOrNull(fileName: String): DBMManager<*, *>? {
         val pair = threadLocal.get() ?: return null
         val (app, managers) = pair
         val cfg = configMap?.get(app) ?: return null

--- a/base/src/main/kotlin/com/smeup/dbnative/DBMManager.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/DBMManager.kt
@@ -25,10 +25,12 @@ import com.smeup.dbnative.model.FileMetadata
  * You can consider data source as a container of one or more files of the same type.
  * A datasource can contains either only tables(views) or only documents.
  * File is an abstraction of table, view or document.
+ *
+ * @param Q the backend-specific query input type (e.g. SQLQuery for SQL backends)
+ * @param RS the backend-specific result set type (e.g. java.sql.ResultSet for SQL backends)
  * */
-interface DBMManager : AutoCloseable{
+interface DBMManager<Q, RS> : AutoCloseable {
     val connectionConfig : ConnectionConfig
-
 
     fun existFile(name: String): Boolean
     fun registerMetadata(metadata: FileMetadata, overwrite: Boolean)
@@ -40,4 +42,5 @@ interface DBMManager : AutoCloseable{
      * Validate connectionConfig. If validation fails, implementation has to throw an IllegalArgumentException
      * */
     fun validateConfig()
+    fun <T> executeQuery(query: Q, block: (RS) -> T): T
 }

--- a/base/src/main/kotlin/com/smeup/dbnative/DBManagerBaseImpl.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/DBManagerBaseImpl.kt
@@ -24,7 +24,7 @@ import com.smeup.dbnative.metadata.file.FSMetadataRegisterImpl
 import com.smeup.dbnative.model.FileMetadata
 import java.util.*
 
-abstract class DBManagerBaseImpl : DBMManager {
+abstract class DBManagerBaseImpl<Q, RS> : DBMManager<Q, RS> {
     var logger: Logger? = null
    /*
     val metadataRegister: MetadataRegister
@@ -57,6 +57,9 @@ abstract class DBManagerBaseImpl : DBMManager {
     override fun existFile(name: String): Boolean {
         return getMetadataRegister().contains(name.uppercase(Locale.getDefault()))
     }
+
+    override fun <T> executeQuery(query: Q, block: (RS) -> T): T =
+        throw UnsupportedOperationException("executeQuery not supported by ${this::class.simpleName}")
 
     companion object {
 

--- a/base/src/main/kotlin/com/smeup/dbnative/mock/MockDBManager.kt
+++ b/base/src/main/kotlin/com/smeup/dbnative/mock/MockDBManager.kt
@@ -6,7 +6,7 @@ import com.smeup.dbnative.DBManagerBaseImpl
 /**
  * Mock implementation of DBManagerBaseImpl
  */
-class MockDBManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {
+class MockDBManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl<Nothing, Nothing>() {
 
     override fun validateConfig() {
     }

--- a/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
+++ b/base/src/test/kotlin/com/smeup/dbnative/ConnectionProviderTest.kt
@@ -37,7 +37,7 @@ private val TEST_CONFIG_B = ConnectionConfig(
 private val ACCESS_CONFIG = DBNativeAccessConfig(listOf(TEST_CONFIG_B, TEST_CONFIG))
 private val CONFIG_MAP = mapOf(TEST_APP to ACCESS_CONFIG)
 
-private fun spyFactory(configMap: Map<String, DBNativeAccessConfig>): Map<String, (ConnectionConfig) -> DBMManager> =
+private fun spyFactory(configMap: Map<String, DBNativeAccessConfig>): Map<String, (ConnectionConfig) -> DBMManager<*, *>> =
     configMap.mapValues { { connConfig: ConnectionConfig -> SpyDBMManager(connConfig) } }
 
 /**
@@ -84,7 +84,7 @@ class ConnectionProviderTest {
     @Test
     fun withScope_closesManagersOnExit() {
         val spies = mutableListOf<SpyDBMManager>()
-        val collectingFactory = CONFIG_MAP.mapValues { { connConfig: ConnectionConfig ->
+        val collectingFactory: Map<String, (ConnectionConfig) -> DBMManager<*, *>> = CONFIG_MAP.mapValues { { connConfig: ConnectionConfig ->
             SpyDBMManager(connConfig).also { spies.add(it) }
         } }
         ConnectionProvider.configure(CONFIG_MAP, collectingFactory)
@@ -140,7 +140,7 @@ class ConnectionProviderTest {
 
     @Test
     fun withScope_scopeIsThreadLocal() {
-        var managerSeenFromOtherThread: DBMManager? = null
+        var managerSeenFromOtherThread: DBMManager<*, *>? = null
         ConnectionProvider.withScope(TEST_APP) {
             val thread = Thread {
                 managerSeenFromOtherThread = ConnectionProvider.currentManagerOrNull("FILEA")
@@ -220,7 +220,7 @@ class ConnectionProviderTest {
 /**
  * Test double used to verify manager creation and closure semantics.
  */
-class SpyDBMManager(override val connectionConfig: ConnectionConfig) : DBMManager {
+class SpyDBMManager(override val connectionConfig: ConnectionConfig) : DBMManager<Nothing, Nothing> {
     var closed = false
 
     override fun existFile(name: String) = false
@@ -230,5 +230,6 @@ class SpyDBMManager(override val connectionConfig: ConnectionConfig) : DBMManage
     override fun closeFile(name: String) {}
     override fun unregisterMetadata(name: String) {}
     override fun validateConfig() {}
+    override fun <T> executeQuery(query: Nothing, block: (Nothing) -> T): T = throw UnsupportedOperationException()
     override fun close() { closed = true }
 }

--- a/jt400/src/main/kotlin/com/smeup/dbnative/jt400/JT400DBMManager.kt
+++ b/jt400/src/main/kotlin/com/smeup/dbnative/jt400/JT400DBMManager.kt
@@ -25,7 +25,7 @@ import com.smeup.dbnative.ConnectionConfig
 import com.smeup.dbnative.DBManagerBaseImpl
 import com.smeup.dbnative.file.DBFile
 
-open class JT400DBMManager(final override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl()  {
+open class JT400DBMManager(final override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl<Nothing, Nothing>() {
 
     private var openedFile = mutableMapOf<String, JT400DBFile>()
 

--- a/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileFactory.kt
+++ b/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileFactory.kt
@@ -47,7 +47,7 @@ class DBFileFactory(
     private val fileNameNormalizer: (String) -> String = {it}
 ) : AutoCloseable {
 
-    private val managers = mutableMapOf<ConnectionConfig, DBMManager> ()
+    private val managers = mutableMapOf<ConnectionConfig, DBMManager<*, *>>()
 
     /**
      * Open the file named fileName. A file can only be opened after registration of its metadata.
@@ -104,10 +104,11 @@ class DBFileFactory(
     }
 }
 
-internal fun createDBManager(config: ConnectionConfig, logger: Logger? = null): DBMManager {
+@Suppress("UNCHECKED_CAST")
+internal fun createDBManager(config: ConnectionConfig, logger: Logger? = null): DBMManager<*, *> {
     val impl = getImplByUrl(config)
 
-    val clazz: Class<DBMManager>? = Class.forName(impl) as Class<DBMManager>?
+    val clazz: Class<out DBMManager<*, *>>? = Class.forName(impl) as Class<out DBMManager<*, *>>?
 
     return clazz?.let {
         val constructor = it.getConstructor(ConnectionConfig::class.java)

--- a/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileWrapper.kt
+++ b/manager/src/main/kotlin/com/smeup/dbnative/manager/DBFileWrapper.kt
@@ -24,7 +24,7 @@ import com.smeup.dbnative.file.Result
 import com.smeup.dbnative.log.Logger
 import com.smeup.dbnative.model.FileMetadata
 
-class DBFileWrapper (private val dbFile: DBFile, private val dbmManager: DBMManager): DBFile {
+class DBFileWrapper (private val dbFile: DBFile, private val dbmManager: DBMManager<*, *>): DBFile {
 
     private var closed = false
 

--- a/nosql/src/main/kotlin/com/smeup/dbnative/nosql/NoSQLDBMManager.kt
+++ b/nosql/src/main/kotlin/com/smeup/dbnative/nosql/NoSQLDBMManager.kt
@@ -32,7 +32,7 @@ import com.smeup.dbnative.file.DBFile
  * Record --> Object in collection
  */
 
-class NoSQLDBMManager (override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {
+class NoSQLDBMManager (override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl<Nothing, Nothing>() {
 
     // MongoDB-related fields
     private var host: String = ""

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/DBMManagerSqlExtensions.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/DBMManagerSqlExtensions.kt
@@ -6,5 +6,5 @@ import javax.sql.DataSource
 /**
  * Adapts this manager to a thread-scoped [DataSource] when it is SQL-based.
  */
-fun DBMManager.toDataSource(): DataSource? =
+fun DBMManager<*, *>.toDataSource(): DataSource? =
     (this as? SQLDBMManager)?.let { ThreadScopedDataSource(it) }

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
@@ -20,12 +20,15 @@ package com.smeup.dbnative.sql
 import com.smeup.dbnative.ConnectionConfig
 import com.smeup.dbnative.DBManagerBaseImpl
 import com.smeup.dbnative.log.LoggingKey
+import com.smeup.dbnative.log.TelemetrySpan
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.ResultSet
 import java.util.*
 import kotlin.system.measureTimeMillis
 
-open class SQLDBMManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl() {
+open class SQLDBMManager(override val connectionConfig: ConnectionConfig) : DBManagerBaseImpl<SQLQuery, ResultSet>() {
 
     private var sqlLog: Boolean = false
     private var connectionOpenedAt: Long = 0L
@@ -85,6 +88,58 @@ open class SQLDBMManager(override val connectionConfig: ConnectionConfig) : DBMa
             }
             statement.executeBatch()
         }
+    }
+
+    override fun <T> executeQuery(query: SQLQuery, block: (ResultSet) -> T): T {
+        val telemetrySpan = TelemetrySpan("EXECUTE QUERY Execution")
+        logger?.logEvent(LoggingKey.execute_inquiry, "Preparing statement for query: ${query.query} with bindings: ${query.parameters}")
+
+        val stmt: PreparedStatement
+        measureTimeMillis {
+            stmt = connection.prepareStatement(query.query)
+            stmt.bind(query.parameters.map { it ?: "" })
+        }.apply {
+            logger?.logEvent(LoggingKey.execute_inquiry, "Statement prepared, executing query for statement", this)
+        }
+
+        return stmt.use {
+            val rs: ResultSet
+            measureTimeMillis {
+                rs = stmt.executeQuery()
+            }.apply {
+                logger?.logEvent(LoggingKey.execute_inquiry, "Query successfully executed", this)
+            }
+
+            val result: T
+            measureTimeMillis {
+                result = rs.use { block(it) }
+            }.apply {
+                logger?.logEvent(LoggingKey.execute_inquiry, "Consumer completed", this)
+            }
+
+            telemetrySpan.endSpan()
+            result
+        }
+    }
+
+    fun executeQuery(sql: String, values: List<Any>, resultSetType: Int, concurrency: Int): ResultSet {
+        val telemetrySpan = TelemetrySpan("EXECUTE CURSOR QUERY Execution")
+        logger?.logEvent(LoggingKey.execute_inquiry, "Preparing cursor query: $sql with bindings: $values")
+        val stmt: PreparedStatement
+        measureTimeMillis {
+            stmt = connection.prepareStatement(sql, resultSetType, concurrency)
+            stmt.bind(values)
+        }.apply {
+            logger?.logEvent(LoggingKey.execute_inquiry, "Statement prepared", this)
+        }
+        val rs: ResultSet
+        measureTimeMillis {
+            rs = stmt.executeQuery()
+        }.apply {
+            logger?.logEvent(LoggingKey.execute_inquiry, "Cursor query executed", this)
+        }
+        telemetrySpan.endSpan()
+        return rs
     }
 
     fun setSQLLog(on: Boolean) {

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
@@ -122,13 +122,19 @@ open class SQLDBMManager(override val connectionConfig: ConnectionConfig) : DBMa
         }
     }
 
-    fun executeQuery(sql: String, values: List<Any>, resultSetType: Int, concurrency: Int): ResultSet {
+    /**
+     * WARNING: The caller is responsible for closing the returned [ResultSet] and the underlying
+     * [PreparedStatement]. Failing to do so will cause resource leaks.
+     * Prefer [executeQuery] with a lambda block instead — it handles cleanup automatically:
+     *   executeQuery(query) { rs -> ... }
+     */
+    fun executeQuery(query: SQLQuery, resultSetType: Int, concurrency: Int): ResultSet {
         val telemetrySpan = TelemetrySpan("EXECUTE CURSOR QUERY Execution")
-        logger?.logEvent(LoggingKey.execute_inquiry, "Preparing cursor query: $sql with bindings: $values")
+        logger?.logEvent(LoggingKey.execute_inquiry, "Preparing cursor query: ${query.query} with bindings: ${query.parameters}")
         val stmt: PreparedStatement
         measureTimeMillis {
-            stmt = connection.prepareStatement(sql, resultSetType, concurrency)
-            stmt.bind(values)
+            stmt = connection.prepareStatement(query.query, resultSetType, concurrency)
+            stmt.bind(query.parameters.map { it ?: "" })
         }.apply {
             logger?.logEvent(LoggingKey.execute_inquiry, "Statement prepared", this)
         }

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLQuery.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLQuery.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 The Reload project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.dbnative.sql
+
+data class SQLQuery(
+    val query: String,
+    val parameters: List<Any?> = emptyList()
+)

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensionsTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/ConnectionProviderSqlExtensionsTest.kt
@@ -38,7 +38,7 @@ private val POOLED_CONFIG = ConnectionConfig(
     poolConfig = PoolConfig(maximumPoolSize = 2)
 )
 
-private fun sqlFactory(cfg: com.smeup.dbnative.ConnectionConfig): com.smeup.dbnative.DBMManager =
+private fun sqlFactory(cfg: com.smeup.dbnative.ConnectionConfig): com.smeup.dbnative.DBMManager<*, *> =
     SQLDBMManager(cfg)
 
 /**

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/SQLExecuteQueryTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/SQLExecuteQueryTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 The Reload project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.smeup.dbnative.sql
+
+import com.smeup.dbnative.sql.utils.*
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SQLExecuteQueryTest {
+
+    companion object {
+        private lateinit var dbManager: SQLDBMManager
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            dbManager = dbManagerForTest()
+            createAndPopulateMunicipalityTable(dbManager)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            destroyDatabase()
+        }
+    }
+
+    @Test
+    fun `executeQuery returns rows matching placeholder filter`() {
+        val count = dbManager.executeQuery(
+            SQLQuery("SELECT * FROM $MUNICIPALITY_TABLE_NAME WHERE NAZ = ?", listOf("IT"))
+        ) { rs ->
+            var n = 0
+            while (rs.next()) {
+                assertEquals("IT", rs.getString("NAZ").trim())
+                n++
+            }
+            n
+        }
+        assertTrue(count > 0)
+    }
+
+    @Test
+    fun `executeQuery with no matching rows yields empty ResultSet`() {
+        val hasRows = dbManager.executeQuery(
+            SQLQuery("SELECT * FROM $MUNICIPALITY_TABLE_NAME WHERE NAZ = ?", listOf("XX"))
+        ) { rs -> rs.next() }
+        assertFalse(hasRows)
+    }
+
+    @Test
+    fun `executeQuery without parameters returns all rows`() {
+        val hasRows = dbManager.executeQuery(
+            SQLQuery("SELECT * FROM $MUNICIPALITY_TABLE_NAME")
+        ) { rs -> rs.next() }
+        assertTrue(hasRows)
+    }
+
+    @Test
+    fun `resources are closed after block — second call on same query succeeds`() {
+        repeat(2) {
+            dbManager.executeQuery(SQLQuery("SELECT * FROM $MUNICIPALITY_TABLE_NAME")) { rs ->
+                assertTrue(rs.next())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Introduces a generic `executeQuery` API on `DBMManager` for cases where callers need to run arbitrary SQL (aggregations, joins, DDL) that doesn't map to any file-level operation.

## Summary

### Generic type parameters on `DBMManager`
- Makes `DBMManager` and `DBManagerBaseImpl` generic (`<Q, RS>`) so each backend can expose a strongly-typed `executeQuery` API
- Non-SQL backends (JT400, NoSQL, Mock) use `DBManagerBaseImpl<Nothing, Nothing>`
- All `DBMManager<*, *>` references in `ConnectionProvider`, `DBFileFactory`, `DBFileWrapper`, and extension functions updated accordingly

### `executeQuery` API
- Adds `fun <T> executeQuery(query: Q, block: (RS) -> T): T` to `DBMManager`; the default implementation in `DBManagerBaseImpl` throws `UnsupportedOperationException`
- Introduces `SQLQuery(query: String, parameters: List<Any?> = emptyList())` data class for the SQL backend
- Implements `executeQuery` in `SQLDBMManager` using `SQLQuery` and `java.sql.ResultSet`; statement and result set are closed automatically via the lambda block
- Replaces the raw `executeQuery(sql: String, values: List<Any>, resultSetType, concurrency)` cursor overload with `executeQuery(query: SQLQuery, resultSetType, concurrency)`

## Test plan

- [x] `SQLExecuteQueryTest` — placeholder filter, empty result set, no-param query, resource-closure guarantee
- [x] `ConnectionProviderTest` — existing scope, thread-local, and close semantics tests still pass
- [x] `ConnectionProviderSqlExtensionsTest` — `toDataSource()` extension still resolves correctly