### PR TITLE
perf(sql): replace connection-scope autocommit with page-based reads

### DIFF
--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/Native2SQLAdapter.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/Native2SQLAdapter.kt
@@ -237,10 +237,38 @@ class Native2SQL(val fileMetadata: FileMetadata, private val dialect: SQLDialect
         val conditions = dialect.buildPositioningConditions(
             fileMetadata.fileKeys, inst.keys, inst.method, forward, ::buildReplacements
         )
-        val sql = conditions.joinToString(" UNION ") { (where, _) ->
+        var sql = conditions.joinToString(" UNION ") { (where, _) ->
             "SELECT $columns FROM $tableName WHERE $where"
         } + " ${getSQLOrderByClause()}"
+        dialect.pageSize()?.let { sql += " FETCH FIRST $it ROWS ONLY" }
         return Pair(sql, conditions.flatMap { it.second })
+    }
+
+    /**
+     * True while a positioning-based query (bounded by [SQLDialect.pageSize] and thus subject to
+     * transparent page resume) is the active read path, as opposed to CHAIN or an un-positioned
+     * full-table READ, neither of which go through [buildDialectPositioningSQL].
+     */
+    fun hasPositioning(): Boolean = lastPositioningInstruction != null
+
+    fun pageSize(): Int? = dialect.pageSize()
+
+    /**
+     * Builds the SQL to continue a positioning-based scan once its current page (capped by
+     * [SQLDialect.pageSize]) is exhausted, seeking strictly past [lastRecord] in the current read
+     * direction. Replaces [lastPositioningInstruction] but deliberately leaves [lastReadInstruction]
+     * untouched (unlike [setPositioning]) so the caller-visible read cycle (e.g. the original
+     * readEqual key filter) is unaffected by this internal repage.
+     */
+    fun getResumeSqlStatement(lastRecord: Record): Pair<String, List<String>> {
+        checkPositioning()
+        val forward = lastReadInstruction!!.method.forward
+        val resumeMethod = if (forward) PositioningMethod.SETGT else PositioningMethod.SETLL
+        val resumeKeys = fileMetadata.fileKeys.map { lastRecord[it].orEmpty() }
+        lastPositioningInstruction = PositioningInstruction(resumeMethod, resumeKeys)
+        val columns = fileMetadata.fields.joinToString(", ") { "\"${it.name}\"" }
+        val tableName = "\"${fileMetadata.tableName}\""
+        return buildDialectPositioningSQL(columns, tableName, forward)
     }
 
     fun getReadSqlStatement(): Pair<String, List<String>> {

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBFile.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBFile.kt
@@ -57,6 +57,7 @@ class SQLDBFile(
 
     private var adapter: Native2SQL = Native2SQL(this.fileMetadata, dialect)
     private var eof: Boolean = false
+    private var rowsInCurrentPage: Int = 0
 
     private fun logEvent(loggingKey: LoggingKey, message: String, elapsedTime: Long? = null) =
         logger?.logEvent(loggingKey, message, elapsedTime, lastNativeMethod, fileMetadata.name)
@@ -340,6 +341,7 @@ class SQLDBFile(
 
     private fun executeQuery(sql: String, values: List<String>) {
         eof = false
+        rowsInCurrentPage = 0
         closeResultSet()
         logEvent(LoggingKey.execute_inquiry, "Preparing statement for query: $sql with bingings: $values")
         val stm: PreparedStatement
@@ -370,17 +372,28 @@ class SQLDBFile(
         while (!found && !eof) {
             count++
             if (result.record.isEmpty()) {
-                eof = true
-                result.indicatorEQ = true
-                closeResultSet()
-                logEvent(LoggingKey.read_data, "No more record to read")
+                val pageSize = adapter.pageSize()
+                val canResumeNextPage = adapter.hasPositioning() && actualRecord != null &&
+                        pageSize != null && rowsInCurrentPage == pageSize
+                if (canResumeNextPage) {
+                    logEvent(LoggingKey.read_data, "Page of $pageSize rows exhausted, fetching next page")
+                    executeQuery(adapter.getResumeSqlStatement(actualRecord!!))
+                    result = Result(resultSet.toValues())
+                } else {
+                    eof = true
+                    result.indicatorEQ = true
+                    closeResultSet()
+                    logEvent(LoggingKey.read_data, "No more record to read")
+                }
             }
             else if (adapter.lastReadMatchRecord(result.record)) {
                 logEvent(LoggingKey.read_data, "Record read: ${result.record}")
                 actualRecord = result.record.duplicate()
+                rowsInCurrentPage++
                 eof = false
                 found = true
             } else {
+                rowsInCurrentPage++
                 logEvent(LoggingKey.read_data, "Readed records: ${count}")
                 if (exitOnUnmatch) {
                     eof = true

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDBMManager.kt
@@ -35,7 +35,10 @@ open class SQLDBMManager(override val connectionConfig: ConnectionConfig) : DBMa
 
     open val dialect: SQLDialect by lazy {
         val enabled = connectionConfig.properties["reload.dialect.enabled"] != "false"
-        if (enabled) SQLDialect.forUrl(connectionConfig.url) else DefaultSQLDialect()
+        // Passed through as-is (absent/non-numeric -> null); each SQLDialect implementation
+        // decides what null (and a zero-or-negative value) means for itself.
+        val pageSize = connectionConfig.properties["reload.dialect.pageSize"]?.toIntOrNull()
+        if (enabled) SQLDialect.forUrl(connectionConfig.url, pageSize) else DefaultSQLDialect(pageSize)
     }
 
     protected val openedFiles = mutableListOf<SQLDBFile>()

--- a/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDialect.kt
+++ b/sql/src/main/kotlin/com/smeup/dbnative/sql/SQLDialect.kt
@@ -24,6 +24,16 @@ interface SQLDialect {
     fun fetchSize(): Int? = null
 
     /**
+     * Max rows a single positioning-based SELECT returns (via `FETCH FIRST n ROWS ONLY`),
+     * or null for no cap. Standard SQL, supported by PostgreSQL, DB2/AS400, and HSQLDB: without
+     * it, the query is planned as an unbounded range scan, since the only signal the optimizer
+     * has that not all matching rows will be fetched is a generic assumption (e.g. PostgreSQL's
+     * cursor_tuple_fraction, ~10% of the match by default). Native2SQL transparently re-queries
+     * for the next page once a page is fully consumed, so this is invisible to DBFile callers.
+     */
+    fun pageSize(): Int? = 100
+
+    /**
      * Called once, right after a new physical [Connection] is obtained (opened or borrowed
      * from a pool), before any query runs. Allows dialects to apply connection-scoped setup
      * for the whole lifetime of this connection (e.g. session timeouts, autoCommit mode).
@@ -39,11 +49,23 @@ interface SQLDialect {
     fun onConnectionClosing(connection: Connection, commit: Boolean) {}
 
     companion object {
-        fun forUrl(url: String): SQLDialect = when {
-            url.startsWith("jdbc:postgresql", ignoreCase = true) -> PostgreSQLDialect()
-            else -> DefaultSQLDialect()
+        fun forUrl(url: String, pageSize: Int? = null): SQLDialect = when {
+            url.startsWith("jdbc:postgresql", ignoreCase = true) -> PostgreSQLDialect(pageSize = pageSize)
+            url.startsWith("jdbc:as400", ignoreCase = true) -> DB2400Dialect(pageSize = pageSize)
+            else -> DefaultSQLDialect(pageSize = pageSize)
         }
     }
+}
+
+/**
+ * Resolves the raw `reload.dialect.pageSize` value (as passed through by [SQLDialect.forUrl])
+ * against a dialect's own default: `null` means the property wasn't set, so [default] applies;
+ * zero or negative is an explicit opt-out, meaning no cap regardless of [default].
+ */
+private fun resolvePageSize(pageSize: Int?, default: Int?): Int? = when {
+    pageSize == null -> default
+    pageSize <= 0 -> null
+    else -> pageSize
 }
 
 private fun comparisonFor(method: PositioningMethod, forward: Boolean): Pair<Comparison, Comparison> =
@@ -54,7 +76,36 @@ private fun comparisonFor(method: PositioningMethod, forward: Boolean): Pair<Com
         else                                          -> Pair(Comparison.LE, Comparison.LT)
     }
 
-class DefaultSQLDialect : SQLDialect {
+/**
+ * Per-key-level UNION strategy: one fragment per key-prefix length, combined by Native2SQL
+ * with UNION. Portable to any engine, since it doesn't rely on row-value constructor support.
+ */
+private fun unionPositioningConditions(
+    fileKeys: List<String>,
+    positioningKeys: List<String>,
+    method: PositioningMethod,
+    forward: Boolean,
+    buildReplacements: (List<String>) -> List<String>
+): List<Pair<String, List<String>>> {
+    val (firstCmp, otherCmp) = comparisonFor(method, forward)
+    return (positioningKeys.size downTo 1).map { i ->
+        val where = (0 until i).joinToString(" AND ") { idx ->
+            val cmp = when {
+                idx < i - 1               -> Comparison.EQ.symbol
+                i == positioningKeys.size -> firstCmp.symbol
+                else                      -> otherCmp.symbol
+            }
+            "\"${fileKeys[idx]}\" $cmp ?"
+        }
+        Pair(where, buildReplacements(positioningKeys.subList(0, i)))
+    }
+}
+
+class DefaultSQLDialect(pageSize: Int? = null) : SQLDialect {
+
+    private val pageSize: Int? = resolvePageSize(pageSize, default = 100)
+
+    override fun pageSize(): Int? = pageSize
 
     override fun buildPositioningConditions(
         fileKeys: List<String>,
@@ -62,56 +113,40 @@ class DefaultSQLDialect : SQLDialect {
         method: PositioningMethod,
         forward: Boolean,
         buildReplacements: (List<String>) -> List<String>
-    ): List<Pair<String, List<String>>> {
-        val (firstCmp, otherCmp) = comparisonFor(method, forward)
-        return (positioningKeys.size downTo 1).map { i ->
-            val where = (0 until i).joinToString(" AND ") { idx ->
-                val cmp = when {
-                    idx < i - 1               -> Comparison.EQ.symbol
-                    i == positioningKeys.size -> firstCmp.symbol
-                    else                      -> otherCmp.symbol
-                }
-                "\"${fileKeys[idx]}\" $cmp ?"
-            }
-            Pair(where, buildReplacements(positioningKeys.subList(0, i)))
-        }
-    }
+    ): List<Pair<String, List<String>>> =
+        unionPositioningConditions(fileKeys, positioningKeys, method, forward, buildReplacements)
 }
 
-class PostgreSQLDialect(
-    // Safety net: a query's ResultSet may legitimately stay open (and its transaction with
-    // it) across many separate native read calls, since callers aren't required to close it
-    // promptly. Bounding how long the resulting transaction can sit idle prevents an abandoned
-    // ResultSet from holding locks that block other connections (e.g. DDL) indefinitely.
-    private val idleInTransactionTimeoutMs: Long = 30_000
-) : SQLDialect {
+/**
+ * DB2 for i (AS400), reached via the IBM Toolbox JDBC driver (`jdbc:as400://...`,
+ * com.ibm.as400.access.AS400JDBCDriver). Uses the same portable per-key-level UNION strategy
+ * as [DefaultSQLDialect] rather than PostgreSQL's row-value tuple comparison, since row-value
+ * constructor support for inequality comparisons isn't confirmed across DB2-for-i versions.
+ */
+class DB2400Dialect(pageSize: Int? = null) : SQLDialect {
 
-    override fun fetchSize(): Int? = 100
+    // Unlike the other dialects, absent config leaves this uncapped by default: row-value/FETCH
+    // FIRST behavior across DB2-for-i versions isn't validated yet, so opt-in via
+    // reload.dialect.pageSize until that's confirmed on real AS400 hardware.
+    private val pageSize: Int? = resolvePageSize(pageSize, default = null)
 
-    private var savedAutoCommit: Boolean? = null
+    override fun pageSize(): Int? = pageSize
 
-    override fun onConnectionOpened(connection: Connection) {
-        connection.createStatement().use {
-            it.execute("SET idle_in_transaction_session_timeout = $idleInTransactionTimeoutMs")
-        }
-        savedAutoCommit = connection.autoCommit
-        connection.autoCommit = false
-    }
+    override fun buildPositioningConditions(
+        fileKeys: List<String>,
+        positioningKeys: List<String>,
+        method: PositioningMethod,
+        forward: Boolean,
+        buildReplacements: (List<String>) -> List<String>
+    ): List<Pair<String, List<String>>> =
+        unionPositioningConditions(fileKeys, positioningKeys, method, forward, buildReplacements)
+}
 
-    override fun onConnectionClosing(connection: Connection, commit: Boolean) {
-        savedAutoCommit?.let { saved ->
-            try {
-                if (!connection.autoCommit) {
-                    if (commit) connection.commit() else connection.rollback()
-                }
-                connection.autoCommit = saved
-            } catch (t: Throwable) {
-                // Connection may already be dead, e.g. terminated server-side by
-                // idle_in_transaction_session_timeout after being abandoned by the caller.
-            }
-            savedAutoCommit = null
-        }
-    }
+class PostgreSQLDialect(pageSize: Int? = null) : SQLDialect {
+
+    private val pageSize: Int? = resolvePageSize(pageSize, default = 100)
+
+    override fun pageSize(): Int? = pageSize
 
     override fun buildPositioningConditions(
         fileKeys: List<String>,

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/PostgreSQLDialectTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/PostgreSQLDialectTest.kt
@@ -1,52 +1,10 @@
 package com.smeup.dbnative.sql
 
-import org.junit.After
 import org.junit.Test
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.Statement
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
-
-/**
- * Fake [Connection] backed by a real HSQLDB connection (for members we don't care about),
- * with [createStatement]/`autoCommit`/[commit]/[rollback] intercepted and recorded so
- * [PostgreSQLDialect]'s connection-lifecycle hooks can be tested without a real PostgreSQL
- * instance. `execute` on statements created here is recorded but never actually run against
- * HSQLDB, since [PostgreSQLDialect] issues PostgreSQL-only syntax.
- */
-private class TrackingConnection(private val real: Connection) : Connection by real {
-    val executedSql = mutableListOf<String>()
-    var commitCount = 0
-    var rollbackCount = 0
-    var throwOnCommit = false
-    var throwOnRollback = false
-    private var autoCommitState = real.autoCommit
-
-    override fun createStatement(): Statement {
-        val realStatement = real.createStatement()
-        return object : Statement by realStatement {
-            override fun execute(sql: String): Boolean {
-                executedSql.add(sql)
-                return true
-            }
-        }
-    }
-
-    override fun getAutoCommit(): Boolean = autoCommitState
-    override fun setAutoCommit(autoCommit: Boolean) { autoCommitState = autoCommit }
-
-    override fun commit() {
-        commitCount++
-        if (throwOnCommit) throw RuntimeException("connection is dead")
-    }
-
-    override fun rollback() {
-        rollbackCount++
-        if (throwOnRollback) throw RuntimeException("connection is dead")
-    }
-}
 
 class PostgreSQLDialectTest {
 
@@ -55,61 +13,20 @@ class PostgreSQLDialectTest {
     private val posKeys = listOf("A", "B")
     private val identity: (List<String>) -> List<String> = { it }
 
-    private fun newTrackingConnection() =
-        TrackingConnection(DriverManager.getConnection("jdbc:hsqldb:mem:PG_DIALECT_TEST", "sa", "root"))
-
-    @After
-    fun tearDown() {
-        DriverManager.getConnection("jdbc:hsqldb:mem:PG_DIALECT_TEST;shutdown=true", "sa", "root").runCatching { close() }
+    @Test
+    fun `pageSize defaults to 100 when unset`() {
+        assertEquals(100, PostgreSQLDialect().pageSize())
     }
 
     @Test
-    fun `onConnectionOpened sets idle timeout and disables autoCommit`() {
-        val connection = newTrackingConnection()
-        connection.autoCommit = true
-
-        dialect.onConnectionOpened(connection)
-
-        assertEquals(1, connection.executedSql.size)
-        assertTrue(connection.executedSql[0].contains("idle_in_transaction_session_timeout"))
-        assertFalse(connection.autoCommit)
+    fun `pageSize uses the configured value`() {
+        assertEquals(50, PostgreSQLDialect(pageSize = 50).pageSize())
     }
 
     @Test
-    fun `onConnectionClosing commits and restores autoCommit when commit is true`() {
-        val connection = newTrackingConnection()
-        connection.autoCommit = true
-        dialect.onConnectionOpened(connection)
-
-        dialect.onConnectionClosing(connection, commit = true)
-
-        assertEquals(1, connection.commitCount)
-        assertEquals(0, connection.rollbackCount)
-        assertTrue(connection.autoCommit)
-    }
-
-    @Test
-    fun `onConnectionClosing rolls back and restores autoCommit when commit is false`() {
-        val connection = newTrackingConnection()
-        connection.autoCommit = true
-        dialect.onConnectionOpened(connection)
-
-        dialect.onConnectionClosing(connection, commit = false)
-
-        assertEquals(0, connection.commitCount)
-        assertEquals(1, connection.rollbackCount)
-        assertTrue(connection.autoCommit)
-    }
-
-    @Test
-    fun `onConnectionClosing swallows exception from a dead connection`() {
-        val connection = newTrackingConnection()
-        connection.autoCommit = true
-        dialect.onConnectionOpened(connection)
-        connection.throwOnCommit = true
-
-        dialect.onConnectionClosing(connection, commit = true)
-        // no exception propagated
+    fun `pageSize is disabled when configured as zero or negative`() {
+        assertNull(PostgreSQLDialect(pageSize = 0).pageSize())
+        assertNull(PostgreSQLDialect(pageSize = -1).pageSize())
     }
 
     @Test

--- a/sql/src/test/kotlin/com/smeup/dbnative/sql/SQLMunicipalityTest.kt
+++ b/sql/src/test/kotlin/com/smeup/dbnative/sql/SQLMunicipalityTest.kt
@@ -416,6 +416,25 @@ class SQLMunicipalityTest {
         dbManager.closeFile(MUNICIPALITY_TABLE_NAME)
     }
 
+    // Lombardy has 1244 municipalities, well over the default 100-row page cap, so this
+    // exercises the transparent page-resume path in SQLDBFile.readNextFromResultSet several
+    // times over within a single setll+readEqual loop.
+    @Test
+    fun t16_findAllOfLombardyAcrossPageBoundaryWithSetllAndReadE2() {
+        val dbFile = dbManager.openFile(MUNICIPALITY_TABLE_NAME)
+        val key2 = buildMunicipalityKey("IT", "LOM")
+        assertTrue(dbFile.setll(key2))
+        val istatCodes = mutableListOf<String>()
+        while (!dbFile.eof()) {
+            val result = dbFile.readEqual(key2)
+            if (result.record.isNotEmpty()) {
+                istatCodes.add(result.record["ISTAT"]!!)
+            }
+        }
+        assertEquals(1244, istatCodes.size)
+        assertEquals(istatCodes.size, istatCodes.toSet().size)
+        dbManager.closeFile(MUNICIPALITY_TABLE_NAME)
+    }
 
 }
 


### PR DESCRIPTION
## Summary

Investigation into a ~4x end-to-end slowdown of PostgreSQL vs DB2 IBMi (fully detailed in `logs.txt`-based analysis, available on request) traced the gap almost entirely to `readEqual` (cursor-scan) operations, while `chain` (point-lookup) performance was already on par between the two databases.

## Root cause

`reload`'s `readEqual` issues an unbounded, fully-sorted positioning query — `WHERE (keys) >= (?, ...) ORDER BY (keys)` with no `LIMIT`/`FETCH FIRST` — relying entirely on JDBC `fetchSize` and cursor semantics to stop fetching early. For starting keys that aren't highly selective (a large share of production traffic), PostgreSQL correctly costs a full/parallel sequential scan + sort as cheaper than an index scan, because the query as written literally asks for the entire sorted tail of the keyset from that key onward. This isn't a missing-index or stale-statistics problem — the matching indexes exist and are exact matches for the query's `ORDER BY`; the query shape itself is the issue.

The previous mitigation (per-connection `autoCommit=false` + extended-protocol cursor semantics via `PostgreSQLDialect.onConnectionOpened/onConnectionClosing`) nudged the planner toward index scans by lowering its cost estimate for early termination, but left a large residual cost: even with the correct index, an unselective starting key still means walking the index across a large fraction of the table. It also carried its own risk — an idle, forgotten result set held its transaction open indefinitely, requiring an `idle_in_transaction_session_timeout` safety net and manual commit/rollback bookkeeping.

## Strategy

Replace the connection-scoped autocommit/idle-timeout workaround with a portable, bounded-fetch approach:

- Cap each positioning query with `FETCH FIRST n ROWS ONLY` (standard SQL, supported by PostgreSQL, DB2 for i, and HSQLDB) instead of asking for the full unbounded tail of the keyset.
- Have `Native2SQL` transparently re-query for the next page once a page is exhausted, so the caller-visible read cycle (`setll`/`readEqual`/etc.) is unaffected.
- Make the page size configurable per dialect via a new `reload.dialect.pageSize` connection property (0 or negative disables paging).
- Factor the per-key-level UNION positioning strategy out of `DefaultSQLDialect` into a shared helper, and add a `DB2400Dialect` (`jdbc:as400`) that reuses it, since PostgreSQL's row-value tuple comparison isn't confirmed to be safe across DB2-for-i versions.
- Drop the now-unnecessary `onConnectionOpened`/`onConnectionClosing` autocommit and idle-timeout lifecycle from `PostgreSQLDialect`.

This turns each positioning query into a bounded, cheap request the planner can size accurately, instead of relying on cursor semantics to paper over an unbounded query shape.

## Test plan

- [x] `PostgreSQLDialectTest` updated for `pageSize()` behavior
- [x] New `SQLMunicipalityTest` coverage for reads spanning a page boundary
- [x] CI passes